### PR TITLE
Add placeholder v6 migration

### DIFF
--- a/artgalleryclient/src/main/sqldelight/edu/gvsu/art/client/data/6.sqm
+++ b/artgalleryclient/src/main/sqldelight/edu/gvsu/art/client/data/6.sqm
@@ -1,0 +1,1 @@
+-- no-op to upgrade database to version 7


### PR DESCRIPTION
Attempts to fix the following error which expects a `6.sqm` file:

```
android.database.sqlite.SQLiteException - Can't downgrade database from version 7 to 6
```