### PR TITLE
Upgrade to Android 14, enable debug builds without secrets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId "edu.gvsu.art.gallery"
         minSdkVersion 26
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1008
         versionName "2023.08.1008"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'com.google.firebase.crashlytics'
 Properties properties = new Properties()
 if (rootProject.file("project.properties").exists()) {
     properties.load(rootProject.file("project.properties").newDataInputStream())
+} else {
+    properties.load(rootProject.file("project-sample.properties").newDataInputStream())
 }
 
 Properties secrets = new Properties()
@@ -142,3 +144,21 @@ repositories {
     mavenCentral()
     google()
 }
+
+tasks.register('useGoogleServicesDebugFile') {
+    description 'Copies the debug google-services.json file if file is missing.'
+    doLast {
+        def googleServicesFile = "google-services.json"
+        if (!file("${project.projectDir}/$googleServicesFile").exists()) {
+            def debugOnlyFile = "google-services-debug-only.json"
+            println "$googleServicesFile file is missing. Copying $debugOnlyFile"
+            copy {
+                from "${project.projectDir}/$debugOnlyFile"
+                into project.projectDir
+                rename { googleServicesFile }
+            }
+        }
+    }
+}
+
+preBuild.dependsOn(useGoogleServicesDebugFile)

--- a/app/google-services-debug-only.json
+++ b/app/google-services-debug-only.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "1012557198299",
+    "project_id": "art-at-gvsu-debug",
+    "storage_bucket": "art-at-gvsu-debug.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1012557198299:android:18864c8323c2297ab22dfe",
+        "android_client_info": {
+          "package_name": "edu.gvsu.art.gallery"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyD8EYf8WcAl_B4Q8DvEVoiDq8AWbHGazFI"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.squareup.sqldelight:gradle-plugin:1.5.5'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/project-sample.properties
+++ b/project-sample.properties
@@ -1,0 +1,2 @@
+art_gallery_base_url="https://example.com/api"
+application_name="Demo Gallery"


### PR DESCRIPTION
This change does two things

- Debug builds: Ensures that the app will compile (not yet run) without including any secrets from production builds. Based on https://github.com/Automattic/pocket-casts-android/pull/11.
- Upgrade to Android v34: Updates the target SDK to version 34/Android 14