### PR TITLE
Clear dark map theme if app is in light mode

### DIFF
--- a/app/src/main/java/edu/gvsu/art/gallery/ui/TourDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/TourDetailScreen.kt
@@ -135,7 +135,7 @@ private fun MapView(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
-    val darkTheme = isAppInDarkTheme()
+    val isDarkTheme = isAppInDarkTheme()
     val boundingPadding = with(LocalDensity.current) { 32.dp.roundToPx() }
     val map = rememberMapViewWithLifecycle()
     val (googleMap, setGoogleMap) = remember { mutableStateOf<GoogleMap?>(null) }
@@ -149,13 +149,15 @@ private fun MapView(
         coroutineScope.launch {
             if (googleMap == null) {
                 val awaitedMap = mapView.awaitMap()
-                if (darkTheme) {
+                if (isDarkTheme) {
                     awaitedMap.setMapStyle(
                         MapStyleOptions.loadRawResourceStyle(
                             context,
                             R.raw.google_maps_dark
                         )
                     )
+                } else {
+                    awaitedMap.setMapStyle(null)
                 }
                 val boundsBuilder = LatLngBounds.builder()
 


### PR DESCRIPTION
Closes #18

Fixes an issue where the tour map would display the dark mode view when the app was set to a light theme.

The fix instead is to clear out the map settings to ensure that the dark mode is unset.

<table>
<tr>
<th>Before</th>
<th>After</th>
</th>
</tr>
<tr>
<td valign="top">
<img src="https://github.com/gvsucis/art-at-gvsu-android/assets/9521010/132aaed5-14a6-4ea0-aac1-0dd0448b575f" />
</td>
<td valign="top">
<img src="https://github.com/gvsucis/art-at-gvsu-android/assets/9521010/d73ba809-92f0-463e-a6a8-ec3c65573bc0" />
</td>
</tr>
</table>