### PR TITLE
Downgrade navigation library to 2.6.0, upgrade deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ android {
 }
 
 dependencies {
+    implementation platform('androidx.compose:compose-bom:2023.10.01')
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"
@@ -90,20 +91,20 @@ dependencies {
     implementation 'androidx.camera:camera-lifecycle:1.1.0-alpha03'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
     implementation "androidx.datastore:datastore-preferences:$datastore_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.compose.compiler:compiler:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.compose.ui:ui-util:$compose_version"
+    implementation "androidx.compose.animation:animation"
+    implementation "androidx.compose.compiler:compiler:1.5.3"
+    implementation "androidx.compose.material:material-icons-extended"
+    implementation "androidx.compose.material:material"
+    implementation 'com.google.android.material:material:1.10.0'
+    implementation "androidx.compose.runtime:runtime-livedata"
+    implementation "androidx.compose.ui:ui-tooling"
+    implementation "androidx.compose.ui:ui-util"
     implementation "androidx.datastore:datastore-preferences:$datastore_version"
-    implementation "androidx.navigation:navigation-compose:2.7.4"
+    implementation "androidx.navigation:navigation-compose:2.6.0"
     implementation 'com.google.mlkit:barcode-scanning:17.0.2'
     implementation "com.github.Tlaster:Swiper:0.7.1"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
-    implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
     implementation "com.google.android.exoplayer:exoplayer:$exoplayer_version"
     implementation "com.google.android.exoplayer:extension-okhttp:$exoplayer_version"
@@ -112,29 +113,28 @@ dependencies {
     implementation "io.insert-koin:koin-android:$koin_version"
     implementation "io.insert-koin:koin-androidx-compose:$koin_version"
     implementation "io.insert-koin:koin-core:$koin_version"
-    implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation 'com.google.android.gms:play-services-analytics:17.0.0'
-    implementation 'com.google.android.gms:play-services-location:17.1.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'androidx.activity:activity-compose:1.8.0'
+    implementation 'com.google.android.gms:play-services-analytics:18.0.4'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'com.google.android.gms:play-services-maps:18.2.0'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation platform('com.google.firebase:firebase-bom:32.2.2')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'
-    implementation 'com.google.maps.android:android-maps-utils:2.0.3'
+    implementation 'com.google.maps.android:android-maps-utils:2.2.3'
     implementation 'com.google.maps.android:maps-ktx:3.2.1'
     implementation 'com.google.maps.android:maps-utils-ktx:3.2.1'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':artgalleryclient')
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.mockito:mockito-core:3.6.0'
-    androidTestImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'org.mockito:mockito-core:3.6.0'
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.0.5'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.5.4'
 }
 
 repositories {

--- a/app/src/main/java/edu/gvsu/art/gallery/MainActivity.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/MainActivity.kt
@@ -3,10 +3,15 @@ package edu.gvsu.art.gallery
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -21,12 +26,21 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import edu.gvsu.art.gallery.ui.*
+import edu.gvsu.art.gallery.ui.ArtistDetailScreen
+import edu.gvsu.art.gallery.ui.ArtworkDetailScreen
+import edu.gvsu.art.gallery.ui.BrowseScreen
+import edu.gvsu.art.gallery.ui.FavoriteIndexScreen
+import edu.gvsu.art.gallery.ui.FeaturedArtIndexScreen
+import edu.gvsu.art.gallery.ui.LocationDetailScreen
+import edu.gvsu.art.gallery.ui.LocationIndexScreen
+import edu.gvsu.art.gallery.ui.SearchIndexScreen
+import edu.gvsu.art.gallery.ui.SettingsScreen
+import edu.gvsu.art.gallery.ui.TourDetailScreen
+import edu.gvsu.art.gallery.ui.ToursIndexScreen
 import edu.gvsu.art.gallery.ui.foundation.LocalTabScreen
 import edu.gvsu.art.gallery.ui.theme.ArtAtGVSUTheme
 
 @ExperimentalPagerApi
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 @ExperimentalPermissionsApi
 class MainActivity : ComponentActivity() {
@@ -40,7 +54,6 @@ class MainActivity : ComponentActivity() {
 
 @ExperimentalPermissionsApi
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @Composable
 fun App() {
@@ -51,7 +64,6 @@ fun App() {
 
 @ExperimentalPermissionsApi
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @Composable
 fun BottomNavigationView() {
@@ -118,7 +130,6 @@ fun BottomNavigationView() {
 }
 
 @ExperimentalPermissionsApi
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 @ExperimentalPagerApi
 fun NavGraphBuilder.routing(navController: NavController) {
@@ -129,7 +140,6 @@ fun NavGraphBuilder.routing(navController: NavController) {
 }
 
 @ExperimentalPagerApi
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 fun NavGraphBuilder.featuredGraph(navController: NavController) {
     composable(TabScreen.Browse.route) {
@@ -156,7 +166,6 @@ fun NavGraphBuilder.featuredGraph(navController: NavController) {
 }
 
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 fun NavGraphBuilder.toursGraph(navController: NavController) {
     composable(TabScreen.Tours.route) {
@@ -174,7 +183,6 @@ fun NavGraphBuilder.toursGraph(navController: NavController) {
 }
 
 @ExperimentalPermissionsApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @ExperimentalComposeUiApi
 fun NavGraphBuilder.searchGraph(navController: NavController) {
@@ -186,7 +194,6 @@ fun NavGraphBuilder.searchGraph(navController: NavController) {
 }
 
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 fun NavGraphBuilder.favoritesGraph(navController: NavController) {
     composable(TabScreen.Favorites.route) {
@@ -197,7 +204,6 @@ fun NavGraphBuilder.favoritesGraph(navController: NavController) {
 }
 
 @ExperimentalPagerApi
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 fun NavGraphBuilder.artworkDetailScreen(route: String, navController: NavController) {
     composable(route) { backStackEntry ->
@@ -214,12 +220,5 @@ fun NavGraphBuilder.artistDetailScreen(route: String, navController: NavControll
             navController,
             backStackEntry.arguments?.getString("artist_id")
         )
-    }
-}
-
-@Composable
-fun FakeOutScreen(title: String) {
-    Column {
-        Text("Placeholder for ${title}")
     }
 }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
@@ -1,7 +1,6 @@
 package edu.gvsu.art.gallery.ui
 
 import androidx.annotation.StringRes
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -39,7 +38,6 @@ import java.net.URL
 
 
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @Composable
 fun ArtworkDetailScreen(navController: NavController, artworkID: String?) {
@@ -56,7 +54,6 @@ fun ArtworkDetailScreen(navController: NavController, artworkID: String?) {
     )
 }
 
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 @ExperimentalPagerApi
 @Composable
@@ -119,7 +116,6 @@ fun ArtworkView(
     }
 }
 
-@ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 @ExperimentalPagerApi
 @Composable

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkMediaDialog.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkMediaDialog.kt
@@ -1,5 +1,6 @@
 package edu.gvsu.art.gallery.ui
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -12,8 +13,8 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 import edu.gvsu.art.client.Artwork
 
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @ExperimentalComposeUiApi
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @Composable
 fun ArtworkMediaDialog(

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/MediaScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/MediaScreen.kt
@@ -13,9 +13,6 @@ import com.google.accompanist.pager.PagerState
 import moe.tlaster.swiper.rememberSwiperState
 import java.net.URL
 
-
-@ExperimentalAnimationApi
-@SuppressLint("UnrememberedMutableState")
 @ExperimentalPagerApi
 @Composable
 fun MediaScreen(

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/MediaView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/MediaView.kt
@@ -1,6 +1,10 @@
 package edu.gvsu.art.gallery.ui
 
-import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -10,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
@@ -24,14 +27,12 @@ import com.google.accompanist.pager.PagerState
 import com.mxalbert.zoomable.Zoomable
 import edu.gvsu.art.gallery.lib.MediaTypes
 import edu.gvsu.art.gallery.ui.foundation.VideoPlayer
-import edu.gvsu.art.gallery.ui.foundation.VideoPlayerState
 import edu.gvsu.art.gallery.ui.foundation.rememberRemoteImage
 import edu.gvsu.art.gallery.ui.foundation.rememberVideoPlayerState
 import moe.tlaster.swiper.Swiper
 import moe.tlaster.swiper.SwiperState
 import java.net.URL
 
-@ExperimentalAnimationApi
 @ExperimentalPagerApi
 @Composable
 fun MediaView(

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/PlayerView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/PlayerView.kt
@@ -61,6 +61,7 @@ class PlayerView constructor(
                                 while (true) {
                                     delay(1000)
                                     playerProgressCallBack?.onTimeChanged(contentPosition())
+                                    VideoPool.set(url, contentPosition())
                                 }
                             }
                         }
@@ -81,8 +82,7 @@ class PlayerView constructor(
             }
     }
 
-    fun play(seekPosition: Long? = null) {
-        seekPosition?.let { seekTo(it) }
+    fun play() {
         androidPlayer.player?.playWhenReady = true
         androidPlayer.onResume()
     }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayerState.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayerState.kt
@@ -159,7 +159,7 @@ class VideoPlayerState(
     internal fun onResume() {
         player.registerProgressCallback(progressCallBack)
         player.registerPlayerCallback(playerCallBack)
-        if (isPlaying) player.play(seekPosition = currentPosition)
+        if (isPlaying) player.play()
     }
 
     internal fun onPause() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '1.9.1'
     repositories {
         google()
         mavenCentral()
@@ -9,10 +9,10 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
-        classpath 'com.google.gms:google-services:4.3.15'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.4.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
         classpath 'com.squareup.sqldelight:gradle-plugin:1.5.5'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.8'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.1'
     }
 }
@@ -26,8 +26,7 @@ allprojects {
 
     ext {
         anko_version = '0.10.4'
-        compose_version = '1.5.0'
-        compose_compiler_version = '1.5.1'
+        compose_compiler_version = '1.5.3'
         exoplayer_version = '2.16.1'
         lifecycle_version = '1.1.1'
         nav_version = "1.0.0-alpha02"


### PR DESCRIPTION
- Addresses an issue where navigation causes unexpected slide/scale animation when using compose navigation 2.7 and above. The solution is to downgrade to 2.6 and the problem goes away. See https://issuetracker.google.com/issues/297258205 for details.
- Sets the video's current time from the video player position listener so that the time will be set during instantiation instead of on resume. This avoids any judder when seeking to the video's time on orientation change.