### PR TITLE
Restrict video pool to artwork page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 Properties properties = new Properties()
 if (rootProject.file("project.properties").exists()) {

--- a/app/src/main/java/edu/gvsu/art/gallery/lib/VideoPool.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/lib/VideoPool.kt
@@ -1,60 +1,21 @@
 package edu.gvsu.art.gallery.lib
 
+import android.os.Parcel
+import android.os.Parcelable
 import androidx.compose.ui.geometry.Rect
+import kotlinx.parcelize.Parcelize
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
 
-object VideoPool {
-    const val DEBOUNCE_DELAY = 500L
-
-    private val pool = ConcurrentHashMap<String, Long>()
-
+@Parcelize
+class VideoPool(
+    private val pool: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
+) : Parcelable {
     fun get(url: String): Long {
         return pool[url] ?: 1L
     }
 
     fun set(url: String, position: Long) {
         pool[url] = position
-    }
-
-    private val positionPool = ConcurrentHashMap<String, Rect>()
-
-    fun setRect(videoKey: String, rect: Rect) {
-        if (rect.height <= 0) {
-            removeRect(videoKey)
-        } else {
-            positionPool[videoKey] = rect
-        }
-    }
-
-    fun removeRect(url: String) {
-        positionPool.remove(url)
-    }
-
-    fun fullInScreen(videoKey: String, videoHeight: Int): Boolean {
-        positionPool[videoKey]?.let {
-            return videoHeight == it.height.toInt()
-        }
-        return false
-    }
-
-    fun isMostCenter(videoKey: String, middle: Float): Boolean {
-        if (positionPool.size == 0) {
-            return false
-        }
-        if (positionPool.size == 1) {
-            return true
-        }
-        var centerUrl = videoKey
-        var minGap = Float.MAX_VALUE
-        positionPool.forEach {
-            abs((it.value.top + it.value.bottom) / 2 - middle).let { curGap ->
-                if (curGap < minGap) {
-                    minGap = curGap
-                    centerUrl = it.key
-                }
-            }
-        }
-        return videoKey == centerUrl
     }
 }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -29,9 +30,11 @@ import edu.gvsu.art.gallery.DetailDivider
 import edu.gvsu.art.gallery.R
 import edu.gvsu.art.gallery.extensions.openGoogleMaps
 import edu.gvsu.art.gallery.lib.MediaTypes
+import edu.gvsu.art.gallery.lib.VideoPool
 import edu.gvsu.art.gallery.navigateToArtistDetail
 import edu.gvsu.art.gallery.navigateToArtworkDetail
 import edu.gvsu.art.gallery.ui.foundation.LocalTabScreen
+import edu.gvsu.art.gallery.ui.foundation.LocalVideoPool
 import edu.gvsu.art.gallery.ui.foundation.rememberRemoteImage
 import edu.gvsu.art.gallery.ui.theme.ArtAtGVSUTheme
 import java.net.URL
@@ -41,17 +44,22 @@ import java.net.URL
 @ExperimentalPagerApi
 @Composable
 fun ArtworkDetailScreen(navController: NavController, artworkID: String?) {
+    val videoPool = rememberSaveable { VideoPool() }
     artworkID ?: return Column {}
     val (isFavorite, toggleFavorite) = useFavorite(artworkID = artworkID)
     val (artwork, loading) = useArtwork(id = artworkID)
 
-    ArtworkView(
-        navController = navController,
-        artwork = artwork,
-        loading = loading,
-        isFavorite = isFavorite,
-        toggleFavorite = toggleFavorite,
-    )
+    CompositionLocalProvider(
+        LocalVideoPool provides videoPool
+    ) {
+        ArtworkView(
+            navController = navController,
+            artwork = artwork,
+            loading = loading,
+            isFavorite = isFavorite,
+            toggleFavorite = toggleFavorite,
+        )
+    }
 }
 
 @ExperimentalComposeUiApi
@@ -68,14 +76,16 @@ fun ArtworkView(
     val thumbnailState = rememberPagerState()
     val dialogState = rememberPagerState()
 
-    Column(Modifier
-        .verticalScroll(rememberScrollState())
-        .fillMaxSize()) {
+    Column(
+        Modifier
+            .verticalScroll(rememberScrollState())
+            .fillMaxSize()) {
 
         Box(Modifier.aspectRatio(4 / 3f)) {
-            Box(Modifier
-                .background(MaterialTheme.colors.surface)
-                .fillMaxSize())
+            Box(
+                Modifier
+                    .background(MaterialTheme.colors.surface)
+                    .fillMaxSize())
 
             if (!loading) {
                 ArtworkMediaPager(
@@ -240,10 +250,12 @@ fun PagerImage(url: URL) {
                 .fillMaxWidth()
                 .fillMaxHeight(fraction = 0.5f)
                 .clip(RectangleShape)
-                .background(Brush.verticalGradient(
-                    0f to Color.Transparent,
-                    1.0f to Color.Black.copy(alpha = 0.4f)
-                ))
+                .background(
+                    Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        1.0f to Color.Black.copy(alpha = 0.4f)
+                    )
+                )
         )
     }
 }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/Ambient.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/Ambient.kt
@@ -2,5 +2,8 @@ package edu.gvsu.art.gallery.ui.foundation
 
 import androidx.compose.runtime.compositionLocalOf
 import edu.gvsu.art.gallery.TabScreen
+import edu.gvsu.art.gallery.lib.VideoPool
 
 val LocalTabScreen = compositionLocalOf<TabScreen> { TabScreen.Browse }
+
+val LocalVideoPool = compositionLocalOf { VideoPool() }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/PlayerView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/PlayerView.kt
@@ -20,6 +20,7 @@ class PlayerView constructor(
     url: String,
     zOrderMediaOverlay: Boolean,
     keepScreenOn: Boolean,
+    videoPool: VideoPool,
     backgroundColor: Color?,
     onClick: (() -> Unit)?
 ) {
@@ -61,7 +62,7 @@ class PlayerView constructor(
                                 while (true) {
                                     delay(1000)
                                     playerProgressCallBack?.onTimeChanged(contentPosition())
-                                    VideoPool.set(url, contentPosition())
+                                    videoPool.set(url, contentPosition())
                                 }
                             }
                         }
@@ -78,7 +79,7 @@ class PlayerView constructor(
                 }
                 playerCallBack?.onPrepareStart()
                 prepare()
-                seekTo(VideoPool.get(url))
+                seekTo(videoPool.get(url))
             }
     }
 

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
@@ -35,6 +35,7 @@ fun VideoPlayer(
     onClick: (() -> Unit)? = null,
 ) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val videoPool = LocalVideoPool.current
 
     Box {
         if (playEnable) {
@@ -44,6 +45,7 @@ fun VideoPlayer(
                     zOrderMediaOverlay = zOrderMediaOverlay,
                     keepScreenOn = keepScreenOn,
                     backgroundColor = backgroundColor,
+                    videoPool = videoPool,
                     onClick = onClick
                 ).apply {
                     videoState.bind(this)


### PR DESCRIPTION
Prevent video pool from being shared across instances of the artwork detail page by using an ambient value.

Relates to #20 