### PR TITLE
Add deep linking to artwork page

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,13 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" android:host="artgallery.gvsu.edu" />
+            </intent-filter>
         </activity>
         <!--
              The API key for Google Maps-based APIs is defined as a string resource.

--- a/app/src/main/java/edu/gvsu/art/gallery/MainActivity.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import edu.gvsu.art.gallery.ui.ArtistDetailScreen
@@ -158,7 +159,7 @@ fun NavGraphBuilder.featuredGraph(navController: NavController) {
     composable(Route.BrowseArtworkIndex) {
         FeaturedArtIndexScreen(navController)
     }
-    artworkDetailScreen(Route.FeaturedArtworkDetail, navController)
+    artworkDetailScreen(navController)
     artistDetailScreen(Route.FeaturedArtistDetail, navController)
     composable(Route.Settings) {
         SettingsScreen(navController)
@@ -178,7 +179,6 @@ fun NavGraphBuilder.toursGraph(navController: NavController) {
             tourName = backStackEntry.arguments?.getString("display_name") ?: ""
         )
     }
-    artworkDetailScreen(Route.TourArtworkDetail, navController)
     artistDetailScreen(Route.TourArtistDetail, navController)
 }
 
@@ -189,7 +189,6 @@ fun NavGraphBuilder.searchGraph(navController: NavController) {
     composable(Route.SearchIndex) {
         SearchIndexScreen(navController)
     }
-    artworkDetailScreen(Route.SearchArtworkDetail, navController)
     artistDetailScreen(Route.SearchArtistDetail, navController)
 }
 
@@ -199,14 +198,16 @@ fun NavGraphBuilder.favoritesGraph(navController: NavController) {
     composable(TabScreen.Favorites.route) {
         FavoriteIndexScreen(navController)
     }
-    artworkDetailScreen(Route.FavoritesArtworkDetail, navController)
     artistDetailScreen(Route.FavoritesArtistDetail, navController)
 }
 
 @ExperimentalPagerApi
 @ExperimentalComposeUiApi
-fun NavGraphBuilder.artworkDetailScreen(route: String, navController: NavController) {
-    composable(route) { backStackEntry ->
+fun NavGraphBuilder.artworkDetailScreen(navController: NavController) {
+    composable(
+        Route.ArtworkDetail,
+        deepLinks = listOf(navDeepLink { uriPattern = "$ART_GALLERY_WEB_URL/Detail/objects/{artwork_id}" })
+    ) { backStackEntry ->
         ArtworkDetailScreen(
             navController,
             backStackEntry.arguments?.getString("artwork_id")

--- a/app/src/main/java/edu/gvsu/art/gallery/Routing.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/Routing.kt
@@ -10,23 +10,22 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 
+const val ART_GALLERY_WEB_URL = "https://artgallery.gvsu.edu"
+
 object Route {
     const val BrowseArtworkIndex = "browse/artworks"
     const val BrowseIndex = "browse"
     const val BrowseLocationDetail = "browse/locations/{location_id}?display_name={display_name}"
     const val BrowseLocationsIndex = "browse/locations"
     const val FavoritesArtistDetail = "favorites/artists/{artist_id}"
-    const val FavoritesArtworkDetail = "favorites/artworks/{artwork_id}"
+    const val ArtworkDetail = "artworks/{artwork_id}"
     const val FavoritesIndex = "favorites"
     const val FeaturedArtistDetail = "browse/artists/{artist_id}"
-    const val FeaturedArtworkDetail = "browse/artworks/{artwork_id}"
     const val TourIndex = "tours"
     const val TourDetail = "tours/{tour_id}?display_name={display_name}"
     const val TourArtistDetail = "tours/artists/{artist_id}"
-    const val TourArtworkDetail = "tours/artworks/{artwork_id}"
     const val SearchIndex = "search"
     const val SearchArtistDetail = "search/artists/{artist_id}"
-    const val SearchArtworkDetail = "search/artworks/{artwork_id}"
     const val Settings = "browse/settings"
 }
 
@@ -35,25 +34,25 @@ sealed class TabScreen(
     @StringRes val title: Int,
     val icon: ImageVector,
 ) {
-    object Browse : TabScreen(
+    data object Browse : TabScreen(
         route = Route.BrowseIndex,
         title = R.string.navigation_Browse,
         icon = Icons.Default.AutoStories
     )
 
-    object Tours : TabScreen(
+    data object Tours : TabScreen(
         route = Route.TourIndex,
         title = R.string.navigation_Tours,
         icon = Icons.Default.Map,
     )
 
-    object Search : TabScreen(
+    data object Search : TabScreen(
         route = "search",
         title = R.string.navigation_Search,
         icon = Icons.Default.Search
     )
 
-    object Favorites : TabScreen(
+    data object Favorites : TabScreen(
         route = Route.FavoritesIndex,
         title = R.string.navigation_Favorites,
         icon = Icons.Default.Favorite
@@ -89,8 +88,8 @@ sealed class TabScreen(
 fun NavController.navigateToArtistDetail(tabScreen: TabScreen, artistID: String) =
     navigate("${tabScreen.route}/artists/$artistID")
 
-fun NavController.navigateToArtworkDetail(tabScreen: TabScreen, artworkID: String) =
-    navigate("${tabScreen.route}/artworks/${artworkID}")
+fun NavController.navigateToArtworkDetail(artworkID: String) =
+    navigate("artworks/${artworkID}")
 
 fun NavController.navigateToLocation(locationID: String, displayName: String) =
     navigate("browse/locations/$locationID?display_name=${displayName}")

--- a/app/src/main/java/edu/gvsu/art/gallery/lib/Links.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/lib/Links.kt
@@ -1,12 +1,13 @@
 package edu.gvsu.art.gallery.lib
 
 import android.net.Uri
+import edu.gvsu.art.gallery.ART_GALLERY_WEB_URL
 import java.net.URL
 
 
 object Links {
     fun artworkDetail(id: String) =
-        URL("https://artgallery.gvsu.edu/Detail/objects/${id}").toString()
+        URL("${ART_GALLERY_WEB_URL}/Detail/objects/${id}").toString()
 
     fun fromDetailLink(
         url: Uri,

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/ArtistDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/ArtistDetailScreen.kt
@@ -25,7 +25,7 @@ fun ArtistDetailScreen(navController: NavController, artistID: String?) {
 
     val currentTab = LocalTabScreen.current
     fun navigateToArtwork(artworkID: String) {
-        navController.navigateToArtworkDetail(currentTab, artworkID)
+        navController.navigateToArtworkDetail(artworkID)
     }
 
     val artist = when (val data = useArtist(artistID)) {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/ArtworkDetailScreen.kt
@@ -177,7 +177,7 @@ fun ArtworkDetailBody(
     val context = LocalContext.current
     val descriptionRows = artwork.asDescriptionRows
     fun navigateToArtwork(artworkID: String) {
-        navController.navigateToArtworkDetail(currentTab, artworkID)
+        navController.navigateToArtworkDetail(artworkID)
     }
 
     Box(modifier = Modifier

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/BrowseScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/BrowseScreen.kt
@@ -112,7 +112,7 @@ fun HomeFeaturedImageView(
         if (currentArtwork.id.isBlank()) {
             return
         }
-        navController.navigateToArtworkDetail(currentTab, currentArtwork.id)
+        navController.navigateToArtworkDetail(currentArtwork.id)
     }
     Surface(
         modifier = Modifier

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/FavoriteIndexScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/FavoriteIndexScreen.kt
@@ -19,7 +19,6 @@ import androidx.navigation.NavController
 import edu.gvsu.art.client.Artwork
 import edu.gvsu.art.gallery.R
 import edu.gvsu.art.gallery.Route
-import edu.gvsu.art.gallery.TabScreen
 import edu.gvsu.art.gallery.lib.Async
 import edu.gvsu.art.gallery.navigateToArtworkDetail
 
@@ -29,7 +28,7 @@ fun FavoriteIndexScreen(navController: NavController) {
     val data = useFavorites()
 
     fun navigateToArtwork(artworkID: String) {
-        navController.navigateToArtworkDetail(TabScreen.Favorites, artworkID = artworkID)
+        navController.navigateToArtworkDetail(artworkID = artworkID)
     }
 
     fun navigateToBrowse() {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/FeaturedArtIndexScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/FeaturedArtIndexScreen.kt
@@ -32,7 +32,7 @@ fun FeaturedArtIndexScreen(navController: NavController) {
     }
 
     fun navigateToArtwork(id: String) {
-        navController.navigateToArtworkDetail(currentTab, id)
+        navController.navigateToArtworkDetail(id)
     }
 
     Column {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/LocationDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/LocationDetailScreen.kt
@@ -67,7 +67,7 @@ private fun LocationList(navController: NavController, location: Location) {
             navController.navigateToLocation(selected.id, selected.name)
         }
         artworks(artworks = location.artworks) { selected ->
-            navController.navigateToArtworkDetail(tabScreen, selected.id)
+            navController.navigateToArtworkDetail(selected.id)
         }
     }
 }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/SearchIndexScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/SearchIndexScreen.kt
@@ -67,7 +67,7 @@ fun SearchIndexScreen(navController: NavController) {
                 navController.navigateToArtistDetail(tabScreen, artist.id)
             },
             onArtworkSelect = { artwork ->
-                navController.navigateToArtworkDetail(tabScreen, artwork.id)
+                navController.navigateToArtworkDetail(artwork.id)
             }
         )
     }
@@ -121,7 +121,7 @@ fun QRScannerDialog(
         Links.fromDetailLink(
             url = parsedURL,
             onArtwork = { id ->
-                navController.navigateToArtworkDetail(tabScreen, id)
+                navController.navigateToArtworkDetail(id)
             }
         )
     }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/TourDetailScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/TourDetailScreen.kt
@@ -51,7 +51,7 @@ fun TourDetailScreen(navController: NavController, tourID: String?, tourName: St
 
     fun navigateToArtwork(artworkID: String) {
         coroutineScope.launch {
-            navController.navigateToArtworkDetail(tabScreen, artworkID)
+            navController.navigateToArtworkDetail(artworkID)
         }
     }
 


### PR DESCRIPTION
Associates the Artwork Detail page with the existing `artgallery.gvsu.edu/Detail/objects/:id` route. Example: https://artgallery.gvsu.edu/Detail/objects/6308.

This works after manually choosing to open the app by default. Ideally this will be auto-verified in future by an `assetlinks.json` file to the website.

- <https://developers.google.com/digital-asset-links/v1/getting-started>