### PR TITLE
Fix tonemap and UV coordinates

### DIFF
--- a/app/src/main/java/edu/gvsu/art/gallery/ui/artwork/detail/ArtworkDetailViewModel.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/artwork/detail/ArtworkDetailViewModel.kt
@@ -52,14 +52,14 @@ class ArtworkDetailViewModel(
 
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                artworks.find(args.artworkID).fold(
-                    onSuccess = {
-                        _artwork.value = Async.Success(it)
-                    },
-                    onFailure = {
-                        _artwork.value = Async.Failure(it)
-                    }
-                )
+                val value = artworks.find(args.artworkID)
+
+                withContext(Dispatchers.Main) {
+                    _artwork.value = value.fold(
+                        onSuccess = { Async.Success(it) },
+                        onFailure = { Async.Failure(it) }
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes the washed out AR video colors by calling "inverseTonemapSRGB" on the video texture color. This ensures that the tonemap is correctly set when the video is recognized.

<table>
<tr>
<th>Before</th>
<th>After</th>
</th>
</tr>
<tr>
<td valign="top">
<img src="https://github.com/gvsucis/art-at-gvsu-android/assets/9521010/ac4e3052-3236-4a99-8fe9-80b8b10a8a45">
</td>
<td valign="top">
<img src="https://github.com/gvsucis/art-at-gvsu-android/assets/9521010/7eacd1cc-2c2e-4182-aa7c-f8089bd27757">
</td>
</tr>
</table>

Additionally this commit removes the extra call to rotate the final image texture. This is due to how Filament, the 3D library beneath ARCore, handles UV (XY) coordinates by default

> When set to true (default value), the Y coordinate of
> UV attributes will be flipped when read by this
> material's vertex shader.

Relates to

- https://github.com/google/filament/issues/3067
- https://github.com/SceneView/sceneform-android/issues/437