### PR TITLE
Swap in "featured_ar" slug in saved search

### DIFF
--- a/app/src/main/java/edu/gvsu/art/gallery/ui/browse/ArtworkCollectionView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/browse/ArtworkCollectionView.kt
@@ -65,6 +65,6 @@ fun ArtworkCollectionView(
 fun title(collection: ArtworkCollection): String {
     return when(collection) {
         ArtworkCollection.FeaturedArt -> stringResource(R.string.navigation_collection_featured)
-        ArtworkCollection.AR -> stringResource(R.string.navigation_collection_augmented_reality)
+        ArtworkCollection.FeaturedAR -> stringResource(R.string.navigation_collection_augmented_reality)
     }
 }

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/browse/BrowseScreen.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/browse/BrowseScreen.kt
@@ -33,7 +33,6 @@ import edu.gvsu.art.client.Artwork
 import edu.gvsu.art.client.ArtworkCollection
 import edu.gvsu.art.gallery.R
 import edu.gvsu.art.gallery.Route
-import edu.gvsu.art.gallery.lib.Async
 import edu.gvsu.art.gallery.navigateToArtworkDetail
 import edu.gvsu.art.gallery.navigateToCollection
 import edu.gvsu.art.gallery.ui.foundation.LocalTabScreen
@@ -93,7 +92,7 @@ fun BrowseScreen(
             }
 
             BrowseAction(text = R.string.home_ar_collection) {
-                navController.navigateToCollection(ArtworkCollection.AR)
+                navController.navigateToCollection(ArtworkCollection.FeaturedAR)
             }
 
             BrowseAction(text = R.string.home_browse_campuses) {

--- a/artgalleryclient/src/main/kotlin/edu/gvsu/art/client/ArtworkCollection.kt
+++ b/artgalleryclient/src/main/kotlin/edu/gvsu/art/client/ArtworkCollection.kt
@@ -2,7 +2,7 @@ package edu.gvsu.art.client
 
 enum class ArtworkCollection(val slug: String) {
     FeaturedArt("featured_art"),
-    AR("AR_Alten_2022");
+    FeaturedAR("featured_ar");
 
     companion object {
         fun find(slug: String): ArtworkCollection? {


### PR DESCRIPTION
Swap in the `featured_ar` slug instead of the Alten 2022 slug for displaying featured AR works.

<img src="https://github.com/gvsucis/art-at-gvsu-android/assets/9521010/b939ea77-1411-4832-943a-ac69c46fc300" width="400px">
