### PR TITLE
Fix video aspect ratio bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation "androidx.camera:camera-extensions:${camerax_version}"
     implementation 'androidx.camera:camera-view:1.0.0-alpha23'
     implementation 'androidx.camera:camera-lifecycle:1.1.0-alpha03'
+    implementation 'androidx.media3:media3-ui:1.3.1'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
     implementation "androidx.datastore:datastore-preferences:$datastore_version"
     implementation "androidx.compose.animation:animation"
@@ -107,8 +108,8 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
-    implementation "com.google.android.exoplayer:exoplayer:2.19.1"
-    implementation "com.google.android.exoplayer:extension-okhttp:2.19.1"
+    implementation "androidx.media3:media3-exoplayer:1.1.1"
+    implementation "androidx.media3:media3-datasource-okhttp:1.1.1"
     implementation "com.squareup.sqldelight:android-driver:1.5.3"
     implementation "io.coil-kt:coil-compose:2.6.0"
     implementation "io.insert-koin:koin-android:$koin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,19 +107,19 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
-    implementation "com.google.android.exoplayer:exoplayer:$exoplayer_version"
-    implementation "com.google.android.exoplayer:extension-okhttp:$exoplayer_version"
+    implementation "com.google.android.exoplayer:exoplayer:2.19.1"
+    implementation "com.google.android.exoplayer:extension-okhttp:2.19.1"
     implementation "com.squareup.sqldelight:android-driver:1.5.3"
     implementation "io.coil-kt:coil-compose:2.6.0"
     implementation "io.insert-koin:koin-android:$koin_version"
     implementation "io.insert-koin:koin-androidx-compose:$koin_version"
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation 'androidx.activity:activity-compose:1.8.0'
-    implementation 'com.google.android.gms:play-services-analytics:18.0.4'
-    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'com.google.android.gms:play-services-analytics:18.1.0'
+    implementation 'com.google.android.gms:play-services-location:21.3.0'
     implementation 'com.google.android.gms:play-services-maps:18.2.0'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation platform('com.google.firebase:firebase-bom:32.2.2')
+    implementation platform('com.google.firebase:firebase-bom:33.1.2')
     implementation 'com.gorisse.thomas.sceneform:sceneform:1.23.0'
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'

--- a/app/src/main/java/edu/gvsu/art/gallery/lib/CacheDataSourceFactory.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/lib/CacheDataSourceFactory.kt
@@ -1,20 +1,23 @@
 package edu.gvsu.art.gallery.lib
 
 import android.content.Context
-import com.google.android.exoplayer2.upstream.*
-import com.google.android.exoplayer2.upstream.cache.CacheDataSink
-import com.google.android.exoplayer2.upstream.cache.CacheDataSource
-import com.google.android.exoplayer2.upstream.cache.SimpleCache
-import com.google.android.exoplayer2.util.Util
+import androidx.media3.common.util.Util
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.FileDataSource
+import androidx.media3.datasource.cache.CacheDataSink
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.SimpleCache
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import edu.gvsu.art.gallery.BuildConfig
 
+@androidx.media3.common.util.UnstableApi
 class CacheDataSourceFactory(
     private val context: Context,
     private val maxFileSize: Long,
 ) : DataSource.Factory {
-    private val simpleCache: SimpleCache by lazy {
-        VideoCache.getInstance(context)
-    }
+    private val simpleCache: SimpleCache = VideoCache.getInstance(context)
 
     private val defaultDatasourceFactory: DefaultDataSource.Factory
     override fun createDataSource(): DataSource {

--- a/app/src/main/java/edu/gvsu/art/gallery/lib/VideoCache.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/lib/VideoCache.kt
@@ -1,12 +1,13 @@
 package edu.gvsu.art.gallery.lib
 
 import android.content.Context
-import com.google.android.exoplayer2.database.StandaloneDatabaseProvider
-import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor
-import com.google.android.exoplayer2.upstream.cache.SimpleCache
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
 import java.io.File
 
-object VideoCache {
+@UnstableApi object VideoCache {
     private var simpleCache: SimpleCache? = null
     private const val maxCacheSize: Long = 100 * 1024 * 1024L
     fun getInstance(context: Context): SimpleCache {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/MediaView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/MediaView.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
@@ -74,11 +73,10 @@ fun MediaView(
                 }) {
                     videoState?.let {
                         VideoPlayer(
-                            playEnable = true,
                             videoState = it,
+                            playEnable = true,
                             zOrderMediaOverlay = true,
                             keepScreenOn = true,
-                            backgroundColor = Color.Blue,
                         )
                         AnimatedVisibility(
                             visible = videoControlVisibility,

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/MediaPlayerView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/MediaPlayerView.kt
@@ -6,17 +6,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.ui.StyledPlayerView
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.ui.PlayerView
 import edu.gvsu.art.gallery.lib.CacheDataSourceFactory
 import edu.gvsu.art.gallery.lib.VideoPool
 import edu.gvsu.art.gallery.ui.get
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-class PlayerView constructor(
+@UnstableApi
+class MediaPlayerView(
     url: String,
     zOrderMediaOverlay: Boolean,
     keepScreenOn: Boolean,
@@ -33,7 +39,7 @@ class PlayerView constructor(
     private var playerProgressCallBack: PlayerProgressCallBack? = null
     private var playerCallBack: PlayerCallBack? = null
 
-    private var androidPlayer = StyledPlayerView(context).also { playerView ->
+    private var androidPlayer = PlayerView(context).also { playerView ->
         (playerView.videoSurfaceView as? SurfaceView)?.setZOrderMediaOverlay(zOrderMediaOverlay)
         playerView.useController = false
         playerView.keepScreenOn = keepScreenOn

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/MediaPlayerView.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/MediaPlayerView.kt
@@ -11,6 +11,9 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FILL
+import androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT
+import androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH
 import androidx.media3.ui.PlayerView
 import edu.gvsu.art.gallery.lib.CacheDataSourceFactory
 import edu.gvsu.art.gallery.lib.VideoPool
@@ -27,8 +30,6 @@ class MediaPlayerView(
     zOrderMediaOverlay: Boolean,
     keepScreenOn: Boolean,
     videoPool: VideoPool,
-    backgroundColor: Color?,
-    onClick: (() -> Unit)?
 ) {
     private var job: Job? = null
 
@@ -41,6 +42,7 @@ class MediaPlayerView(
 
     private var androidPlayer = PlayerView(context).also { playerView ->
         (playerView.videoSurfaceView as? SurfaceView)?.setZOrderMediaOverlay(zOrderMediaOverlay)
+        playerView.resizeMode = RESIZE_MODE_FILL
         playerView.useController = false
         playerView.keepScreenOn = keepScreenOn
     }.apply {
@@ -53,9 +55,11 @@ class MediaPlayerView(
                             Player.STATE_BUFFERING -> {
                                 playerCallBack?.onBuffering()
                             }
+
                             Player.STATE_READY -> {
                                 playerCallBack?.onReady()
                             }
+
                             else -> {}
                         }
                     }
@@ -122,7 +126,7 @@ class MediaPlayerView(
     }
 
     @Composable
-    fun Content(modifier: Modifier, update: () -> Unit) {
+    fun Content(update: () -> Unit = {}, modifier: Modifier) {
         AndroidView(
             factory = {
                 androidPlayer

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
@@ -1,8 +1,10 @@
 package edu.gvsu.art.gallery.ui.foundation
 
 
+import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -22,17 +24,16 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.media3.common.util.UnstableApi
 
+@OptIn(UnstableApi::class)
 @Composable
 fun VideoPlayer(
-    modifier: Modifier = Modifier.fillMaxSize(), // must set video player size
     videoState: VideoPlayerState,
     playEnable: Boolean = true,
     zOrderMediaOverlay: Boolean = false,
     keepScreenOn: Boolean = false,
     thumb: @Composable() (() -> Unit)? = null,
-    backgroundColor: Color? = null,
-    onClick: (() -> Unit)? = null,
 ) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val videoPool = LocalVideoPool.current
@@ -44,9 +45,7 @@ fun VideoPlayer(
                     url = videoState.url,
                     zOrderMediaOverlay = zOrderMediaOverlay,
                     keepScreenOn = keepScreenOn,
-                    backgroundColor = backgroundColor,
                     videoPool = videoPool,
-                    onClick = onClick
                 ).apply {
                     videoState.bind(this)
                 }
@@ -71,8 +70,15 @@ fun VideoPlayer(
                 }
             }
 
-            Box {
-                mediaPlayerView.Content(modifier = modifier) {}
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                mediaPlayerView.Content(
+                    modifier = Modifier
+                        .aspectRatio(16 / 9f)
+                        .fillMaxSize()
+                )
             }
         }
         if ((videoState.showThumbnail || !playEnable) && thumb != null) {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayer.kt
@@ -39,8 +39,8 @@ fun VideoPlayer(
 
     Box {
         if (playEnable) {
-            val playerView = remember(videoState.url) {
-                PlayerView(
+            val mediaPlayerView = remember(videoState.url) {
+                MediaPlayerView(
                     url = videoState.url,
                     zOrderMediaOverlay = zOrderMediaOverlay,
                     keepScreenOn = keepScreenOn,
@@ -66,13 +66,13 @@ fun VideoPlayer(
                 lifecycle.addObserver(observer)
                 onDispose {
                     videoState.onPause()
-                    playerView.release()
+                    mediaPlayerView.release()
                     lifecycle.removeObserver(observer)
                 }
             }
 
             Box {
-                playerView.Content(modifier = modifier) {}
+                mediaPlayerView.Content(modifier = modifier) {}
             }
         }
         if ((videoState.showThumbnail || !playEnable) && thumb != null) {

--- a/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayerState.kt
+++ b/app/src/main/java/edu/gvsu/art/gallery/ui/foundation/VideoPlayerState.kt
@@ -44,7 +44,7 @@ class VideoPlayerState(
     volume: Float,
     isMute: Boolean,
 ) {
-    private lateinit var player: PlayerView
+    private lateinit var player: MediaPlayerView
 
     private var _isReady = mutableStateOf(isReady)
     var isReady
@@ -151,7 +151,7 @@ class VideoPlayerState(
         if (isReady) player.play()
     }
 
-    fun bind(player: PlayerView) {
+    fun bind(player: MediaPlayerView) {
         this.player = player
         initPlay()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
         classpath 'com.squareup.sqldelight:gradle-plugin:1.5.5'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.1'
     }
 }
@@ -27,7 +27,6 @@ allprojects {
     ext {
         anko_version = '0.10.4'
         compose_compiler_version = '1.5.3'
-        exoplayer_version = '2.16.1'
         lifecycle_version = '1.1.1'
         nav_version = "1.0.0-alpha02"
         paging_version = '1.0.0'


### PR DESCRIPTION
Closes #46

Set 16:9 aspect ratio and fill the content pane to ensure that videos don't appear warped on newer versions of Android.

<table>
<tr>
<th>Before</th>
<th>After</th>
</th>
</tr>
<tr>
<td valign="top">
<img src="https://github.com/user-attachments/assets/a9f25afe-27d4-4bb2-9dea-4b940523f116" width="500px">
</td>
<td valign="top">
<img src="https://github.com/user-attachments/assets/d76a9dde-5261-4ece-a1b6-f7489cfbdb64" width="500px">
</td>
</tr>
</table>